### PR TITLE
Fix encoding in parse_signed_request.

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -385,9 +385,13 @@ class Auth(object):
                                            ((4 - len(encoded_sig) % 4) % 4))
             data = base64.urlsafe_b64decode(payload + "=" *
                                             ((4 - len(payload) % 4) % 4))
+
+            # Base64 is decoded to a bytestring, and json.loads below
+            # only takes (unicode) strings in Python3.
+            data = data.decode('utf-8')
         except IndexError:
             raise ValueError('signed_request malformed')
-        except TypeError:
+        except (TypeError, UnicodeDecodeError):
             raise ValueError('signed_request had corrupted payload')
 
         data = json.loads(data)


### PR DESCRIPTION
Python2 and 3 both return a bytestring from b64decode.

Python3 refuses to take a bytestring as argument to json.dumps: hence,
we decode it from utf-8 first. Python2 doesn't care either way.

```
$ python2 -c 'import json, base64; \
   print(json.loads(base64.b64decode(u"eyJ4IjoiXHUyMGFjIn0=")
         .decode("utf-8")))'
{u'x': u'\u20ac'}
$ python3 -c 'import json, base64; \
   print(json.loads(base64.b64decode(u"eyJ4IjoiXHUyMGFjIn0=")
         .decode("utf-8")))'
{'x': '€'}
```
